### PR TITLE
Layers 2.1 (backwards compatible)

### DIFF
--- a/res/layout/confirm_add_detail_activity.xml
+++ b/res/layout/confirm_add_detail_activity.xml
@@ -44,7 +44,7 @@
             android:layout_alignRight="@id/photo"
             android:layout_alignStart="@id/photo"
             android:layout_alignEnd="@id/photo"
-            android:background="#7F000000" />
+            android:background="@color/photo_text_bar_bg" />
 
         <ImageButton
             android:id="@+id/open_details_button"
@@ -81,7 +81,7 @@
                 android:paddingLeft="8dip"
                 android:paddingStart="8dip"
                 android:gravity="center_vertical"
-                android:textColor="@android:color/white"
+                android:textColor="@color/text_color_white"
                 android:textSize="16sp"
                 android:singleLine="true" />
 
@@ -94,7 +94,7 @@
                 android:paddingStart="8dip"
                 android:gravity="center_vertical"
                 android:textAppearance="?android:attr/textAppearanceSmall"
-                android:textColor="@android:color/white"
+                android:textColor="@color/text_color_white"
                 android:singleLine="true"
                 android:paddingBottom="4dip"
                 android:visibility="gone" />

--- a/res/layout/editor_account_header.xml
+++ b/res/layout/editor_account_header.xml
@@ -20,7 +20,7 @@
     android:layout_height="wrap_content"
     android:layout_width="match_parent"
     android:minHeight="48dip"
-    android:background="#EEEEEE"
+    android:background="@color/editor_account_header_bg"
     android:orientation="horizontal"
     android:paddingTop="8dip"
     android:paddingBottom="8dip"

--- a/res/layout/photoselection_activity.xml
+++ b/res/layout/photoselection_activity.xml
@@ -21,7 +21,7 @@
         android:id="@+id/backdrop"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
-        android:background="#000000" />
+        android:background="@color/photo_backdrop_bg" />
     <view
         android:id="@+id/photo"
         class="com.android.contacts.detail.TransformableImageView"

--- a/res/values/custom_colors.xml
+++ b/res/values/custom_colors.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Copyright (C) 2007 The Android Open Source Project
+
+     Licensed under the Apache License, Version 2.0 (the "License");
+     you may not use this file except in compliance with the License.
+     You may obtain a copy of the License at
+
+          http://www.apache.org/licenses/LICENSE-2.0
+
+     Unless required by applicable law or agreed to in writing, software
+     distributed under the License is distributed on an "AS IS" BASIS,
+     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+     See the License for the specific language governing permissions and
+     limitations under the License.
+-->
+
+<resources>
+    <color name="text_color_white">@color/exposed_primary_text_dark</color>
+    <color name="photo_text_bar_bg">#7F000000</color>
+    <color name="editor_account_header_bg">@color/exposed_account_header_bg</color>
+    <color name="photo_backdrop_bg">#000000</color>
+    <color name="list_item_name_text_color">@color/exposed_contact_list_name_text_color</color>
+    <color name="white">@color/exposed_bg_dark</color>
+    <color name="contacts_action_bar_text_hint">@color/exposed_ContactsActionBarTheme_hint</color>
+    <color name="contacts_action_bar_text_color">@color/exposed_ContactsActionBarTheme_text</color>
+    <color name="section_divider_bg">@color/exposed_SectionDivider</color>
+    <color name="edit_kind_text_appearance_text_color">@color/exposed_EditKindTextAppearanceStyle</color>
+</resources> 

--- a/res/values/layers_colors.xml
+++ b/res/values/layers_colors.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Copyright (C) 2007 The Android Open Source Project
+     Licensed under the Apache License, Version 2.0 (the "License");
+     you may not use this file except in compliance with the License.
+     You may obtain a copy of the License at
+          http://www.apache.org/licenses/LICENSE-2.0
+     Unless required by applicable law or agreed to in writing, software
+     distributed under the License is distributed on an "AS IS" BASIS,
+     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+     See the License for the specific language governing permissions and
+     limitations under the License.
+-->
+
+<resources>
+    <!-- Exposed resources for theming -->
+    <color name="exposed_account_header_bg">#EEEEEE</color>
+    <color name="exposed_bg_dark">#ffffffff</color>
+    <color name="exposed_primary_text_dark">@android:color/white</color>
+    <color name="exposed_contact_list_name_text_color">#ff212121</color>
+    <color name="exposed_ContactsActionBarTheme_hint">#CCCCCC</color>
+    <color name="exposed_ContactsActionBarTheme_text">@android:color/black</color>
+    <color name="exposed_SectionDivider">#7e7e87</color>
+    <color name="exposed_EditKindTextAppearanceStyle">#363636</color>
+</resources> 

--- a/res/values/styles.xml
+++ b/res/values/styles.xml
@@ -49,25 +49,29 @@
         <item name="android:actionBarItemBackground">@drawable/item_background_material_borderless_dark</item>
     </style>
 
-    <style name="PeopleTheme" parent="@android:style/Theme.Material.Light">
+    <style name="PeopleTheme1" parent="@android:style/Theme.Material.Light">
         <item name="android:actionBarStyle">@style/ContactsActionBarStyle</item>
         <!-- Style for the tab bar (for the divider between tabs) -->
         <item name="android:actionBarTabBarStyle">@style/ContactsActionBarTabBarStyle</item>
         <!-- Style for the tab bar text (for text on tabs) -->
         <item name="android:actionBarTabTextStyle">@style/ContactsActionBarTabTextStyle</item>
-        <!--  Drawable for the back button -->
-        <item name="android:homeAsUpIndicator">@drawable/ic_back_arrow</item>
-        <!-- Style for the overflow button in the actionbar. -->
-        <item name="android:actionOverflowButtonStyle">@style/ContactsActionBarOverflowQP</item>
-        <item name="android:fastScrollThumbDrawable">@drawable/fastscroll_thumb</item>
         <item name="android:textColorPrimary">@color/primary_text_color</item>
         <item name="android:textColorSecondary">@color/secondary_text_color</item>
-        <item name="android:icon">@android:color/transparent</item>
         <item name="android:listViewStyle">@style/ListViewStyle</item>
         <item name="android:windowBackground">@color/background_primary</item>
         <item name="android:colorPrimaryDark">@color/primary_color_dark</item>
         <item name="android:colorPrimary">@color/primary_color</item>
         <item name="android:colorAccent">@color/primary_color</item>
+    </style>
+
+    <style name="PeopleTheme" parent="@style/PeopleTheme1">
+        <!--  Drawable for the back button -->
+        <item name="android:homeAsUpIndicator">@drawable/ic_back_arrow</item>
+        <!-- Style for the overflow button in the actionbar. -->
+        <item name="android:actionOverflowButtonStyle">@style/ContactsActionBarOverflowQP</item>
+        <item name="android:fastScrollThumbDrawable">@drawable/fastscroll_thumb</item>
+        <item name="android:fastScrollTrackDrawable">@null</item>
+        <item name="android:icon">@android:color/transparent</item>
         <item name="android:alertDialogTheme">@style/ContactsAlertDialogTheme</item>
         <item name="list_item_height">?android:attr/listPreferredItemHeight</item>
         <item name="activated_background">@drawable/list_item_activated_background</item>
@@ -80,6 +84,7 @@
         <item name="list_item_padding_bottom">
             @dimen/contact_browser_list_item_padding_top_or_bottom
         </item>
+        <item name="list_item_name_text_color">@color/list_item_name_text_color</item>
         <item name="list_item_padding_left">16dip</item>
         <item name="list_item_gap_between_image_and_text">
             @dimen/contact_browser_list_item_gap_between_image_and_text
@@ -136,10 +141,10 @@
     </style>
 
     <style name="ContactPickerSearchTheme" parent="@style/PeopleTheme">
-        <item name="android:textColorPrimary">@android:color/white</item>
+        <item name="android:textColorPrimary">@color/text_color_white</item>
         <item name="android:textColorHint">?android:textColorHintInverse</item>
         <item name="android:colorControlActivated">?android:textColorHintInverse</item>
-        <item name="android:colorControlNormal">@android:color/white</item>
+        <item name="android:colorControlNormal">@color/white</item>
     </style>
 
     <!-- Text in the action bar at the top of the screen -->
@@ -174,8 +179,8 @@
     </style>
 
     <style name="ContactsActionBarTheme" parent="@android:style/Theme.Holo.Light">
-        <item name="android:textColorHint">#CCCCCC</item>
-        <item name="android:textColor">@android:color/black</item>
+        <item name="android:textColorHint">@color/contacts_action_bar_text_hint</item>
+        <item name="android:textColor">@color/contacts_action_bar_text_color</item>
         <item name="android:popupMenuStyle">@android:style/Widget.Holo.Light.PopupMenu</item>
         <item name="android:dropDownListViewStyle">@style/ListViewDropdownStyle</item>
     </style>
@@ -219,7 +224,7 @@
     </style>
 
     <style name="SectionDivider">
-        <item name="android:background">#7e7e87</item>
+        <item name="android:background">@color/section_divider_bg</item>
         <item name="android:layout_height">1dip</item>
         <item name="android:layout_width">match_parent</item>
     </style>
@@ -298,7 +303,7 @@
         <item name="android:textSize">14sp</item>
         <item name="android:textStyle">bold</item>
         <item name="android:textAllCaps">true</item>
-        <item name="android:textColor">#363636</item>
+        <item name="android:textColor">@color/edit_kind_text_appearance_text_color</item>
         <item name="android:fontFamily">sans-serif</item>
     </style>
 


### PR DESCRIPTION
This is a rework of the initial layers type 2 commit:

Changes naming conventions to coexist with CMTE/AOSP naming

Layers : Exposing hard coded resources for type 2 overlay access [3/6]
Author: bgill55
https://github.com/BitSyko/platform_packages_apps_Contacts/commit/db84ccbabf8ac0c52d9117461fc31f0a14c23a97

Layers : Let's split styles.xml and expose a couple of layouts.
Author: CallMeAldy
https://github.com/BitSyko/platform_packages_apps_Contacts/commit/6cab6194b7a67ec02c10e061d7d0a9fdda16809c

Expose the editor account header background & contact list text colors.
Author: 93Akkord
https://github.com/CyanogenMod/android_packages_apps_Contacts/commit/e0bb86ec5014a07a87a35aa6c25abd13e4ace77a

Make colors backwards compatible with layers previous commits based on:
Author: Andrew Dodd
https://gerrit.omnirom.org/#/c/12695/

Change-Id: Ia7cad2c92a8d340c96f462c5682a1f190d6ceaf8
